### PR TITLE
Flutter 에서 화면 이동하기

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,14 +2,11 @@ import 'package:flutter/material.dart';
 
 void main() {
   runApp(MaterialApp(
-    home: Scaffold(
-        appBar: AppBar(title: const Text('Flutter에서 화면 이동하기')),
-    body: const HomeWidget()),
+    home: HomeWidget(),
   ));
 }
 
 class HomeWidget extends StatefulWidget {
-
   const HomeWidget({super.key});
 
   @override
@@ -17,9 +14,41 @@ class HomeWidget extends StatefulWidget {
 }
 
 class _HomeWidgetState extends State<HomeWidget> {
+  late int index;
+
+  @override
+  void initState() {
+    super.initState();
+    index = 0;
+  }
 
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return Scaffold(
+      appBar: AppBar(title: Text('Flutter에서 화면 이동하기')),
+      body: homeBody(index),
+      bottomNavigationBar: BottomNavigationBar(
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
+          BottomNavigationBarItem(icon: Icon(Icons.search), label: 'Search'),
+          BottomNavigationBarItem(icon: Icon(Icons.person), label: 'User')
+        ],
+        currentIndex: index,
+        onTap: (newValue) => setState(() => index = newValue),
+      ),
+    );
+  }
+
+  Widget homeBody(int index) {
+    switch (index) {
+      case 0:
+        return Center(child: Icon(Icons.home, size: 200));
+      case 1:
+        return Center(child: Icon(Icons.search, size: 200));
+      case 2:
+        return Center(child: Icon(Icons.person, size: 200));
+      default:
+        return Center(child: Icon(Icons.bug_report, size: 200));
+    }
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,54 +1,29 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_example/screen/new_page.dart';
 
 void main() {
   runApp(MaterialApp(
-    home: HomeWidget(),
+    home: Scaffold(
+      appBar: AppBar(
+        title: const Text('Flutter에서 화면 이동하기'),
+      ),
+      body: const HomeWidget(),
+    ),
   ));
 }
 
-class HomeWidget extends StatefulWidget {
+class HomeWidget extends StatelessWidget {
   const HomeWidget({super.key});
 
   @override
-  State<HomeWidget> createState() => _HomeWidgetState();
-}
-
-class _HomeWidgetState extends State<HomeWidget> {
-  late int index;
-
-  @override
-  void initState() {
-    super.initState();
-    index = 0;
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: Text('Flutter에서 화면 이동하기')),
-      body: homeBody(index),
-      bottomNavigationBar: BottomNavigationBar(
-        items: const [
-          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
-          BottomNavigationBarItem(icon: Icon(Icons.search), label: 'Search'),
-          BottomNavigationBarItem(icon: Icon(Icons.person), label: 'User')
-        ],
-        currentIndex: index,
-        onTap: (newValue) => setState(() => index = newValue),
-      ),
+    return Center(
+      child: TextButton(
+          onPressed: () => {
+                Navigator.push(context,
+                    MaterialPageRoute(builder: (context) => const NewPage()))
+              },
+          child: const Text('Go to Page')),
     );
-  }
-
-  Widget homeBody(int index) {
-    switch (index) {
-      case 0:
-        return Center(child: Icon(Icons.home, size: 200));
-      case 1:
-        return Center(child: Icon(Icons.search, size: 200));
-      case 2:
-        return Center(child: Icon(Icons.person, size: 200));
-      default:
-        return Center(child: Icon(Icons.bug_report, size: 200));
-    }
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,24 +1,25 @@
 import 'package:flutter/material.dart';
 
-const String assetsImagePath = "assets/images";
-const String lakeImage = "$assetsImagePath/lake.jpg";
-
 void main() {
   runApp(MaterialApp(
     home: Scaffold(
-      appBar: AppBar(title: const Text('Flutter에서 로컬 데이터 활용하기')),
-      body: const Body(),
-    ),
+        appBar: AppBar(title: const Text('Flutter에서 화면 이동하기')),
+    body: const HomeWidget()),
   ));
 }
 
-class Body extends StatelessWidget {
+class HomeWidget extends StatefulWidget {
 
-  const Body({super.key});
+  const HomeWidget({super.key});
+
+  @override
+  State<HomeWidget> createState() => _HomeWidgetState();
+}
+
+class _HomeWidgetState extends State<HomeWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return Image.asset(lakeImage);
-
+    return const Placeholder();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,14 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_example/screen/new_page.dart';
+import 'package:go_router/go_router.dart';
 
 void main() {
-  runApp(MaterialApp(
-    home: Scaffold(
-      appBar: AppBar(
-        title: const Text('Flutter에서 화면 이동하기'),
-      ),
-      body: const HomeWidget(),
-    ),
+  runApp(MaterialApp.router(
+    routerConfig: GoRouter(initialLocation: '/', routes: [
+      GoRoute(
+          path: '/', name: 'home', builder: (context, _) => const HomeWidget()),
+      GoRoute(
+          path: '/new1', name: 'new1', builder: (context, _) => const NewPage()),
+      GoRoute(
+          path: '/new2', name: 'new2', builder: (context, _) => const NewPage2())
+    ]),
   ));
 }
 
@@ -17,13 +20,13 @@ class HomeWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: TextButton(
-          onPressed: () => {
-                Navigator.push(context,
-                    MaterialPageRoute(builder: (context) => const NewPage()))
-              },
-          child: const Text('Go to Page')),
+    return Scaffold(
+      appBar: AppBar(title: const Text('Flutter에서 화면 이동하기')),
+      body: Center(
+        child: TextButton(
+            onPressed: () => context.pushNamed('new1'),
+            child: const Text('Go to Page')),
+      ),
     );
   }
 }

--- a/lib/screen/new_page.dart
+++ b/lib/screen/new_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class NewPage extends StatelessWidget {
   const NewPage({super.key});
@@ -7,19 +8,18 @@ class NewPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Wellcome to New page'),
+        title: const Text('Welcome to New page'),
       ),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             TextButton(
-              onPressed: () => Navigator.pop(context),
+              onPressed: () => context.pop(),
               child: const Text('Go to Back'),
             ),
             TextButton(
-                onPressed: () => Navigator.push(context,
-                    MaterialPageRoute(builder: (context) => const NewPage2())),
+                onPressed: () => context.pushNamed('new2'),
                 child: const Text('Go to Page2')),
           ],
         ),
@@ -34,15 +34,14 @@ class NewPage2 extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(title: const Text('Wellcome to New Page2')),
+        appBar: AppBar(title: const Text('Welcome to New Page2')),
         body: Center(
           child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
             TextButton(
-                onPressed: () => Navigator.pop(context),
+                onPressed: () => context.pop(),
                 child: const Text('Go to Back')),
             TextButton(
-                onPressed: () =>
-                    Navigator.popUntil(context, (route) => route.isFirst),
+                onPressed: () => context.goNamed('home'),
                 child: const Text('Go to home')),
           ]),
         ));

--- a/lib/screen/new_page.dart
+++ b/lib/screen/new_page.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+class NewPage extends StatelessWidget {
+  const NewPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Wellcome to New page'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Go to Back'),
+            ),
+            TextButton(
+                onPressed: () => Navigator.push(context,
+                    MaterialPageRoute(builder: (context) => const NewPage2())),
+                child: const Text('Go to Page2')),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class NewPage2 extends StatelessWidget {
+  const NewPage2({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(title: const Text('Wellcome to New Page2')),
+        body: Center(
+          child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+            TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Go to Back')),
+            TextButton(
+                onPressed: () =>
+                    Navigator.popUntil(context, (route) => route.isFirst),
+                child: const Text('Go to home')),
+          ]),
+        ));
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -83,6 +83,19 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: c247a4f76071c3b97bb5ae8912968870d5565644801c5e09f3bc961b4d874895
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.1.1"
   js:
     dependency: transitive
     description:
@@ -99,6 +112,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   matcher:
     dependency: transitive
     description:
@@ -194,3 +215,4 @@ packages:
     version: "2.1.4"
 sdks:
   dart: ">=3.0.5 <4.0.0"
+  flutter: ">=3.7.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   flutter:
     sdk: flutter
   english_words: ^4.0.0
+  go_router: ^12.1.1
 
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
Flutter 에서 화면 이동을 하기 위한 다양한 방법을 알아보았다.

첫번째는 `BottomNavigationBar` 의 상태 관리를 통해 화면 전환 효과를 낼 수 있었고

두번째는 `Navigator` 를 통해 실제 화면을 이동 시켜보았다.

마지막으로 `GoRouter` 라이브러리를 통해 화면을 이동 시켜보았다.

`GoRouter` 는 routes 리스트에 이동하고자 할 경로를 지정해주어야만 해당 경로로 이동할 수 있다.

routes 리스트에는 `GoRoute` 객체가 들어가며,
GoRoute 객체의 필수 파라미터 `path`, `name`, `build` 가 있는데,

`path` 는 웹 주소에 대응하기 위해 웹 주소 방식에 맞게 초기화 해주어 해당 경로로 이동하고,
`name` 은 앱에서 name 에 지정해준 이름으로 해당 경로로 이동할 수 있다.
`builder` 는 `path`, `name`이 호출됐을 때 보여줄 화면 위젯을 지정하면 된다.

이렇게 `GoRouter`는 프로젝트 내에서 사용하는 경로를 한눈에 볼 수 있어 해당 경로에 호출되는 화면이 어떤 것인지 파악에 유리하다.

또한, `GoRoute` 에서 다시 routes 를 지정할 수 있으며 이는 딥링킹에 유리하다.

This closes #20 